### PR TITLE
enums

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -215,7 +215,7 @@ export interface ReceiptDto<ReceiptData> {
   uuid: string;
   createdAt: string; // ms since epoch, unix timestamp
   updatedAt: string; // ms since epoch, unix timestamp
-  type: ReceiptTypeEnum,
+  type: ReceiptTypeEnum2,
   userUuid: string;
   brandUuid: string;
   data: ReceiptData;


### PR DESCRIPTION
example of attempt to better link receipt types and data

but seemingly does not work because the type of `type` is still `any`