### PR TITLE
chore: add presentation options variant of one-click

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,13 @@ export interface PresentationOptions {
 }
 
 /**
+ * Options for creating a Presentation with a one-click uuid.
+ */
+export interface PresentationOneClickOptions extends Omit<PresentationOptions, 'presentationRequestUuid'> {
+  oneClickUuid: string;
+}
+
+/**
  * The presentation object returned from the core service
  */
 export interface PresentationDto {


### PR DESCRIPTION
[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work. There should _usually_ be a 1:1 relationship between a ticket and a PR, but that won't always be the case, so you may link the same ticket to multiple PRs, or add additional ticket links to this PR. If there is no ticket, you should probably create one and use the "added after sprint planning" label,
--->

## Summary
Add interface for presentation options with one click variant.